### PR TITLE
Update valid colors for users

### DIFF
--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 
   * `name` - (Required) The name of the user.
   * `email` - (Required) The user's email address.
-  * `color` - (Optional) The schedule color for the user. Valid options are blue, brown, cayenne, chocolate, crimson, cyan, dark, darkolive, deep, firebrick, forest, goldenrod, gray, green, grey, grey20, indigo, lime, magenta, maroon, medium, midnight, olive, olivedrab, orange, orchid, pink, purple, red, royal, saddle, sea, slate, steel, teal, turquoise or violet.
+  * `color` - (Optional) The schedule color for the user. Valid options are purple, red, green, blue, teal, orange, brown, turquoise, dark-slate-blue, cayenne, orange-red, dark-orchid, dark-slate-grey, lime, dark-magenta, lime-green, midnight-blue, deep-pink, dark-green, dark-orange, dark-cyan, darkolive-green, dark-slate-gray, grey20, firebrick, maroon, crimson, dark-red, dark-goldenrod, chocolate, medium-violet-red, sea-green, olivedrab, forest-green, dark-olive-green, blue-violet, royal-blue, indigo, slate-blue, saddle-brown, or steel-blue.
   * `role` - (Optional) The user role. Account must have the `read_only_users` ability to set a user as a `read_only_user`. Can be `admin`, `limited_user`, `owner`, `read_only_user`, `team_responder` or `user`
   * `job_title` - (Optional) The user's title.
   * `teams` - (Optional, **DEPRECATED**) A list of teams the user should belong to. Please use `pagerduty_team_membership` instead.


### PR DESCRIPTION
Based on the Pagerduty API response when creating a user. If you add `pink`, it responds with:
```
POST API call to https://api.pagerduty.com/users failed 400 Bad Request. Code:
 2001, Errors: [Color must be in purple, red, green, blue, teal, orange, brown, 
turquoise, dark-slate-blue, cayenne, orange-red, dark-orchid, dark-slate-grey, 
lime, dark-magenta, lime-green, midnight-blue, deep-pink, dark-green, dark-orange, 
dark-cyan, darkolive-green, dark-slate-gray, grey20, firebrick, maroon, crimson, 
dark-red, dark-goldenrod, chocolate, medium-violet-red, sea-green, olivedrab, 
forest-green, dark-olive-green, blue-violet, royal-blue, indigo, slate-blue, 
saddle-brown, or steel-blue.]
```